### PR TITLE
Fix path for grunt-string-replace module

### DIFF
--- a/tasks/sass-replace.js
+++ b/tasks/sass-replace.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
         sassReplace = require(path.resolve(__dirname, './lib/main')).init(grunt);
 
     // load 3rd party tasks
-    grunt.task.loadTasks(path.resolve(__dirname, '../node_modules/grunt-string-replace/tasks'));
+    grunt.task.loadTasks(path.resolve(__dirname, '../../grunt-string-replace/tasks'));
 
     grunt.registerMultiTask('sass-replace', 'replaces sass values', function () {
         var scssFiles,


### PR DESCRIPTION
This was probably done for an old version of NPM  when it nested node_modules folders, which it no longer does.

Fixes https://github.com/eliranmal/grunt-sass-replace/issues/1#issue-303702424